### PR TITLE
correct "actions" description

### DIFF
--- a/book/AIDO/15_getting_started/20_simulator.md
+++ b/book/AIDO/15_getting_started/20_simulator.md
@@ -127,7 +127,7 @@ the images. The choice of 8-bit integer values over floating-point values was ma
 
 ### Actions
 
-The simulator uses continuous actions by default. Actions passed to the `step()` function should be numpy arrays containining two numbers between -1 and 1. These two numbers correspond to forward velocity, and a steering angle, respectively. A positive velocity makes the robot go forward, and a positive steering angle makes the robot turn left. There is also a [Gym wrapper class](https://github.com/duckietown/gym-duckietown/blob/daffy/gym_duckietown/wrappers.py) named `DiscreteWrapper` which allows you to use discrete actions (turn left, move forward, turn right) instead of continuous actions if you prefer.
+The simulator uses continuous actions by default. Actions passed to the `step()` function should be numpy arrays containining two numbers between -1 and 1. These two numbers correspond to the left and right wheel input respectively. A positive value makes the wheel go forward, a negative value makes it go backwards. There is also a [Gym wrapper class](https://github.com/duckietown/gym-duckietown/blob/daffy/gym_duckietown/wrappers.py) named `DiscreteWrapper` which allows you to use discrete actions (turn left, move forward, turn right) instead of continuous actions if you prefer.
 
 ### Reward Function
 


### PR DESCRIPTION
During one of the exercises in the ETHZ-AMoD20 class we noticed that the docs are wrong here. From playing around with the simulator (on branch daffy), we noticed that the numbers in the "actions" variable don't correspond to forward velocity and steering angle but actually to the respective wheel inputs.