### PR TITLE
02_software.md: Add missing package names

### DIFF
--- a/book/AIDO/15_getting_started/02_software.md
+++ b/book/AIDO/15_getting_started/02_software.md
@@ -78,7 +78,7 @@ We need Git and [Git LFS][git-lfs].
 
 On Ubuntu you can install both using
 
-    $ apt-get install 
+    $ apt-get install git git-lfs
 
 ## Duckietown Shell {#cm-sw-dts}
 


### PR DESCRIPTION
The instructions for installing git & git lfs on Ubuntu were missing the package names after the install command.